### PR TITLE
Allow node type to be inferred

### DIFF
--- a/OMM/Mappable/NodeType+Mappable.swift
+++ b/OMM/Mappable/NodeType+Mappable.swift
@@ -9,15 +9,15 @@
 public
 extension NodeType {
 
-    func value<T: Mappable>(type: T.Type) throws -> T {
+    func value<T: Mappable>(type: T.Type = T.self) throws -> T {
         return try value(transformedWith: MappableTransform())
     }
 
-    func array<T: Mappable>(type: T.Type) throws -> [T] {
+    func array<T: Mappable>(type: T.Type = T.self) throws -> [T] {
         return try array().map { try $0.value(type) }
     }
 
-    func dictionary<T: Mappable>(type: T.Type) throws -> [String: T] {
+    func dictionary<T: Mappable>(type: T.Type = T.self) throws -> [String: T] {
         return try dictionary().toDictionary { try ($0, $1.value(type)) }
     }
 


### PR DESCRIPTION
By defaulting the argument to `T.self` we can support type inference:

``` swift
let foo = try node.value(String)
let bar: String = try node.value()
```
